### PR TITLE
Upgrade engagement-data-pipeline to v4.0.0

### DIFF
--- a/configurations/docker_image_name.txt
+++ b/configurations/docker_image_name.txt
@@ -1,1 +1,1 @@
-ghcr.io/africasvoices/engagement-data-pipeline:v3.2.0
+ghcr.io/africasvoices/engagement-data-pipeline:v4.0.0


### PR DESCRIPTION
This project is unaffected by the breaking change: https://github.com/AfricasVoices/Engagement-Data-Pipeline/releases/tag/v4.0.0